### PR TITLE
Update plugin compatibility to support build 253.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("232")
-        untilBuild.set("242.*")
+        untilBuild.set("253.*")
     }
 
     signPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ pluginGroup=com.example.txtar
 pluginName=txtar-support
 pluginVersion=1.0.0
 pluginSinceBuild=232
-pluginUntilBuild=242.*
+pluginUntilBuild=253.*
 
 platformType=IC
 platformVersion=2023.2.5


### PR DESCRIPTION
Updated the plugin compatibility range to support IntelliJ IDEA build 253.*.
Modified `build.gradle.kts` and `gradle.properties` to set `untilBuild` to `253.*`.
Verified that the plugin builds and tests pass.

---
*PR created automatically by Jules for task [9694431426864518477](https://jules.google.com/task/9694431426864518477) started by @arran4*