### PR TITLE
Fix Txtar folding grouping and chevron placement

### DIFF
--- a/src/main/kotlin/com/example/txtar/RemoveFileAction.kt
+++ b/src/main/kotlin/com/example/txtar/RemoveFileAction.kt
@@ -15,11 +15,11 @@ class RemoveFileAction : AnAction() {
         val offset = editor.caretModel.offset
         val element = psiFile.findElementAt(offset) ?: return
         
-        // Find HEADER or FILE_CONTENT
+        // Find FILE_ENTRY
         var target: PsiElement? = element
         while (target != null) {
             val type = target.node.elementType
-            if (type == TxtarElementTypes.HEADER || type == TxtarElementTypes.FILE_CONTENT) {
+            if (type == TxtarElementTypes.FILE_ENTRY) {
                 break
             }
             target = target.parent
@@ -31,28 +31,9 @@ class RemoveFileAction : AnAction() {
         
         if (target == null) return
         
-        // Identify the pair
-        var header: PsiElement? = null
-        var content: PsiElement? = null
-        
-        if (target.node.elementType == TxtarElementTypes.HEADER) {
-            header = target
-            val next = header.nextSibling
-            if (next != null && next.node.elementType == TxtarElementTypes.FILE_CONTENT) {
-                content = next
-            }
-        } else {
-            content = target
-            val prev = content.prevSibling
-            if (prev != null && prev.node.elementType == TxtarElementTypes.HEADER) {
-                header = prev
-            }
-        }
-        
         // Remove
         WriteCommandAction.runWriteCommandAction(project) {
-            content?.delete()
-            header?.delete()
+            target.delete()
         }
     }
 
@@ -71,7 +52,7 @@ class RemoveFileAction : AnAction() {
                  var target: PsiElement? = element
                  while (target != null) {
                     val type = target.node.elementType
-                    if (type == TxtarElementTypes.HEADER || type == TxtarElementTypes.FILE_CONTENT) {
+                    if (type == TxtarElementTypes.FILE_ENTRY) {
                         e.presentation.isEnabledAndVisible = true
                         break
                     }

--- a/src/main/kotlin/com/example/txtar/TxtarElementTypes.kt
+++ b/src/main/kotlin/com/example/txtar/TxtarElementTypes.kt
@@ -11,4 +11,5 @@ object TxtarElementTypes {
     
     val COMMENT_BLOCK: IElementType = TxtarTokenType("COMMENT_BLOCK")
     val FILE_CONTENT: IElementType = TxtarTokenType("FILE_CONTENT")
+    val FILE_ENTRY: IElementType = TxtarTokenType("FILE_ENTRY")
 }

--- a/src/main/kotlin/com/example/txtar/TxtarFoldingBuilder.kt
+++ b/src/main/kotlin/com/example/txtar/TxtarFoldingBuilder.kt
@@ -5,6 +5,7 @@ import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
 class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
@@ -14,9 +15,20 @@ class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
         var child = root.firstChild
         while (child != null) {
             val type = child.node.elementType
-            if (type == TxtarElementTypes.COMMENT_BLOCK || type == TxtarElementTypes.FILE_CONTENT) {
+            if (type == TxtarElementTypes.COMMENT_BLOCK) {
                 if (child.textLength > 0) {
                      descriptors.add(FoldingDescriptor(child, child.textRange))
+                }
+            } else if (type == TxtarElementTypes.FILE_ENTRY) {
+                val header = child.node.findChildByType(TxtarElementTypes.HEADER)
+                val fileContent = child.node.findChildByType(TxtarElementTypes.FILE_CONTENT)
+
+                if (header != null && fileContent != null && fileContent.textLength > 0) {
+                    var rangeStart = fileContent.textRange.startOffset
+                    if (header.text.endsWith("\n")) {
+                         rangeStart--
+                    }
+                    descriptors.add(FoldingDescriptor(child, TextRange(rangeStart, fileContent.textRange.endOffset)))
                 }
             }
             child = child.nextSibling
@@ -28,7 +40,7 @@ class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
     override fun getPlaceholderText(node: ASTNode): String? {
         val type = node.elementType
         if (type == TxtarElementTypes.COMMENT_BLOCK) return "..."
-        if (type == TxtarElementTypes.FILE_CONTENT) return "..."
+        if (type == TxtarElementTypes.FILE_ENTRY) return "..."
         return null
     }
 

--- a/src/main/kotlin/com/example/txtar/TxtarParserDefinition.kt
+++ b/src/main/kotlin/com/example/txtar/TxtarParserDefinition.kt
@@ -33,6 +33,7 @@ class TxtarParserDefinition : ParserDefinition {
         
         while (!builder.eof()) {
             if (builder.tokenType == TxtarElementTypes.HEADER) {
+                val entryMarker = builder.mark()
                 builder.advanceLexer()
                 
                 if (builder.tokenType == TxtarElementTypes.CONTENT) {
@@ -42,6 +43,7 @@ class TxtarParserDefinition : ParserDefinition {
                     }
                     contentMarker.done(TxtarElementTypes.FILE_CONTENT)
                 }
+                entryMarker.done(TxtarElementTypes.FILE_ENTRY)
             } else {
                 // Should be unreachable if lexer is correct, but safe fallback
                 builder.advanceLexer()

--- a/src/test/kotlin/com/example/txtar/TxtarLexerTest.kt
+++ b/src/test/kotlin/com/example/txtar/TxtarLexerTest.kt
@@ -64,4 +64,44 @@ class TxtarLexerTest {
         
         assertNull(lexer.tokenType)
     }
+
+    @Test
+    fun testProblematicCase() {
+        val content = "-- input.txt --\ncontent\n\n-- input.txt,v --\nhead\t1.1;"
+        val lexer = TxtarLexer()
+        lexer.start(content, 0, content.length, 0)
+
+        // Header 1: -- input.txt --
+        assertEquals(TxtarElementTypes.HEADER, lexer.tokenType)
+        var tokenText = content.subSequence(lexer.tokenStart, lexer.tokenEnd).toString()
+        assertEquals("-- input.txt --\n", tokenText)
+        lexer.advance()
+
+        // Content 1: content
+        assertEquals(TxtarElementTypes.CONTENT, lexer.tokenType)
+        tokenText = content.subSequence(lexer.tokenStart, lexer.tokenEnd).toString()
+        assertEquals("content\n", tokenText)
+        lexer.advance()
+
+        // Content 2: Empty line
+        assertEquals(TxtarElementTypes.CONTENT, lexer.tokenType)
+        tokenText = content.subSequence(lexer.tokenStart, lexer.tokenEnd).toString()
+        assertEquals("\n", tokenText)
+        lexer.advance()
+
+        // Header 2: -- input.txt,v --
+        // This is where we suspect it might fail if logic is wrong
+        assertEquals(TxtarElementTypes.HEADER, lexer.tokenType)
+        tokenText = content.subSequence(lexer.tokenStart, lexer.tokenEnd).toString()
+        assertEquals("-- input.txt,v --\n", tokenText)
+        lexer.advance()
+
+        // Content 3: head 1.1;
+        assertEquals(TxtarElementTypes.CONTENT, lexer.tokenType)
+        tokenText = content.subSequence(lexer.tokenStart, lexer.tokenEnd).toString()
+        assertEquals("head\t1.1;", tokenText)
+        lexer.advance()
+
+        assertNull(lexer.tokenType)
+    }
 }


### PR DESCRIPTION
This PR addresses the issue where Txtar file collapsing was grouped incorrectly, swallowing subsequent headers and placing the folding chevron on the wrong line.

Changes:
- Introduced `FILE_ENTRY` element type in `TxtarElementTypes`.
- Updated `TxtarParserDefinition` to group `HEADER` and subsequent `FILE_CONTENT` into a `FILE_ENTRY`.
- Updated `TxtarFoldingBuilder` to create folding regions for `FILE_ENTRY` that cover the content (including the newline after the header), ensuring the chevron is associated with the header line and the header remains visible.
- Updated `RemoveFileAction` to target `FILE_ENTRY` for deletion, simplifying the logic and aligning with the new structure.
- Verified correct Lexer behavior with a new test case in `TxtarLexerTest`.

---
*PR created automatically by Jules for task [18157615915988343731](https://jules.google.com/task/18157615915988343731) started by @arran4*