### PR TITLE
Fix Txtar folding to group header and content correctly

### DIFF
--- a/src/main/kotlin/com/example/txtar/TxtarElementTypes.kt
+++ b/src/main/kotlin/com/example/txtar/TxtarElementTypes.kt
@@ -9,4 +9,5 @@ object TxtarElementTypes {
 
     val COMMENT_BLOCK: IElementType = TxtarTokenType("COMMENT_BLOCK")
     val FILE_CONTENT: IElementType = TxtarTokenType("FILE_CONTENT")
+    val FILE_ENTRY: IElementType = TxtarTokenType("FILE_ENTRY")
 }

--- a/src/main/kotlin/com/example/txtar/TxtarFoldingBuilder.kt
+++ b/src/main/kotlin/com/example/txtar/TxtarFoldingBuilder.kt
@@ -14,7 +14,7 @@ class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
         var child = root.firstChild
         while (child != null) {
             val type = child.node.elementType
-            if (type == TxtarElementTypes.COMMENT_BLOCK || type == TxtarElementTypes.FILE_CONTENT) {
+            if (type == TxtarElementTypes.COMMENT_BLOCK || type == TxtarElementTypes.FILE_ENTRY) {
                 if (child.textLength > 0) {
                      descriptors.add(FoldingDescriptor(child, child.textRange))
                 }
@@ -28,7 +28,10 @@ class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
     override fun getPlaceholderText(node: ASTNode): String? {
         val type = node.elementType
         if (type == TxtarElementTypes.COMMENT_BLOCK) return "..."
-        if (type == TxtarElementTypes.FILE_CONTENT) return "..."
+        if (type == TxtarElementTypes.FILE_ENTRY) {
+            val header = node.findChildByType(TxtarElementTypes.HEADER)
+            return header?.text ?: "..."
+        }
         return null
     }
 

--- a/src/main/kotlin/com/example/txtar/TxtarParserDefinition.kt
+++ b/src/main/kotlin/com/example/txtar/TxtarParserDefinition.kt
@@ -33,6 +33,7 @@ class TxtarParserDefinition : ParserDefinition {
         
         while (!builder.eof()) {
             if (builder.tokenType == TxtarElementTypes.HEADER) {
+                val fileMarker = builder.mark()
                 builder.advanceLexer()
                 
                 if (builder.tokenType == TxtarElementTypes.CONTENT) {
@@ -42,6 +43,7 @@ class TxtarParserDefinition : ParserDefinition {
                     }
                     contentMarker.done(TxtarElementTypes.FILE_CONTENT)
                 }
+                fileMarker.done(TxtarElementTypes.FILE_ENTRY)
             } else {
                 // Should be unreachable if lexer is correct, but safe fallback
                 builder.advanceLexer()

--- a/testdata/folding/test_folding.txtar
+++ b/testdata/folding/test_folding.txtar
@@ -1,4 +1,5 @@
 <fold text='...'>comment
-</fold>-- file --
-<fold text='...'>content
+</fold><fold text='-- file --
+'>-- file --
+content
 </fold>


### PR DESCRIPTION
The Txtar plugin's folding behavior was incorrect. It folded only the file content, leaving the header outside the fold. This resulted in the fold toggle appearing on the content line instead of the header line, and the header being separated from the folded content. Additionally, there was confusion about whether the next header was being incorporated into the previous file's content.

This PR fixes the issue by introducing a `FILE_ENTRY` element in the PSI tree that wraps both the `HEADER` and the `FILE_CONTENT`. The folding logic now targets `FILE_ENTRY`, and sets the placeholder text to the header text itself. This effectively hides the content while keeping the header visible, and correctly associates the fold region with the header line.

Changes:
- Added `FILE_ENTRY` to `TxtarElementTypes`.
- Updated `TxtarParserDefinition` to wrap `HEADER` and content in `FILE_ENTRY`.
- Updated `TxtarFoldingBuilder` to fold `FILE_ENTRY`.
- Updated `testdata/folding/test_folding.txtar` to match the new behavior.

---
*PR created automatically by Jules for task [13900593232648936455](https://jules.google.com/task/13900593232648936455) started by @arran4*