### PR TITLE
Add Copy File to Clipboard action

### DIFF
--- a/src/main/kotlin/com/example/txtar/CopyFileToClipboardAction.kt
+++ b/src/main/kotlin/com/example/txtar/CopyFileToClipboardAction.kt
@@ -1,0 +1,40 @@
+package com.arran4.txtar
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.ide.CopyPasteManager
+import java.awt.datatransfer.StringSelection
+
+class CopyFileToClipboardAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE) ?: return
+
+        val offset = editor.caretModel.offset
+        val element = psiFile.findElementAt(offset)
+
+        val (_, content) = TxtarFileEntryUtil.findFileEntry(element)
+
+        val contentStr = content?.text ?: ""
+
+        CopyPasteManager.getInstance().setContents(StringSelection(contentStr))
+    }
+
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE)
+
+        e.presentation.isEnabledAndVisible = false
+
+        if (project != null && editor != null && psiFile != null) {
+             val offset = editor.caretModel.offset
+             val element = psiFile.findElementAt(offset)
+             val (header, content) = TxtarFileEntryUtil.findFileEntry(element)
+             if (header != null || content != null) {
+                 e.presentation.isEnabledAndVisible = true
+             }
+        }
+    }
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -36,6 +36,7 @@
             <action id="Txtar.ReorderFiles" class="com.arran4.txtar.ReorderFilesAction" text="Reorder Files..." description="Reorder file entries"/>
             <action id="Txtar.CalculateFileSize" class="com.arran4.txtar.CalculateFileSizeAction" text="Calculate File Size" description="Calculate size of file"/>
             <action id="Txtar.ExtractFile" class="com.arran4.txtar.ExtractFileAction" text="Extract File..." description="Extract file / save file as"/>
+            <action id="Txtar.CopyFileToClipboard" class="com.arran4.txtar.CopyFileToClipboardAction" text="Copy File to Clipboard" description="Copy content of the file entry to clipboard"/>
             <action id="Txtar.AppendClipboard" class="com.arran4.txtar.AppendFromClipboardAction" text="Append New File from Clipboard" description="Append clipboard content as a new file entry"/>
             <separator/>
             <reference id="CollapseAll"/>


### PR DESCRIPTION
Implemented 'Copy File to Clipboard' action for Txtar files. Users can now right-click inside a file entry within a Txtar file and select 'Copy File to Clipboard' to copy its content. This action is context-sensitive and only enabled when the caret is within a valid file entry.

---
*PR created automatically by Jules for task [5294517581247618935](https://jules.google.com/task/5294517581247618935) started by @arran4*