### PR TITLE
Add dark mode version of plugin icon

### DIFF
--- a/pluginIcon_dark.svg
+++ b/pluginIcon_dark.svg
@@ -1,0 +1,14 @@
+<svg width="400" height="400" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
+  <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2D61B5"/>
+      <stop offset="1" stop-color="#8E25B8"/>
+    </linearGradient>
+  </defs>
+</svg>

--- a/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,0 +1,14 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
+  <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+  <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+  <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  <defs>
+    <linearGradient id="paint0_linear" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#2D61B5"/>
+      <stop offset="1" stop-color="#8E25B8"/>
+    </linearGradient>
+  </defs>
+</svg>


### PR DESCRIPTION
Added dark mode versions of the plugin icon to support IntelliJ Platform's dark theme.
The new icon `src/main/resources/META-INF/pluginIcon_dark.svg` will be automatically picked up by the IDE when running in dark mode.
Also added a high-resolution version at the root for documentation or other uses.

---
*PR created automatically by Jules for task [12736519568908527363](https://jules.google.com/task/12736519568908527363) started by @arran4*