### PR TITLE
Update plugin logo with transparent padding

### DIFF
--- a/pluginIcon.svg
+++ b/pluginIcon.svg
@@ -1,10 +1,12 @@
 <svg width="400" height="400" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
-  <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
-  <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
-  <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  <g transform="translate(4,4) scale(0.8)">
+    <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
+    <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  </g>
   <defs>
     <linearGradient id="paint0_linear" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
       <stop stop-color="#3E86FB"/>

--- a/src/main/resources/META-INF/pluginIcon.svg
+++ b/src/main/resources/META-INF/pluginIcon.svg
@@ -1,10 +1,12 @@
 <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
-  <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
-  <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
-  <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  <g transform="translate(4,4) scale(0.8)">
+    <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
+    <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  </g>
   <defs>
     <linearGradient id="paint0_linear" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
       <stop stop-color="#3E86FB"/>


### PR DESCRIPTION
Updated the plugin logo SVG files to include transparent padding as recommended by JetBrains Marketplace guidelines.
The existing 40x40 content was scaled to 32x32 and centered, providing 4px padding on all sides.
This change affects `src/main/resources/META-INF/pluginIcon.svg` (for plugin distribution) and `pluginIcon.svg` (for repository display).
Verified the changes by building the plugin and ensuring the SVG files remain valid.

---
*PR created automatically by Jules for task [2828748135011874721](https://jules.google.com/task/2828748135011874721) started by @arran4*