### PR TITLE
Fix ReorderFilesAction parsing logic

### DIFF
--- a/src/main/kotlin/com/example/txtar/ReorderFilesAction.kt
+++ b/src/main/kotlin/com/example/txtar/ReorderFilesAction.kt
@@ -41,39 +41,24 @@ class ReorderFilesAction : AnAction() {
             val entries = mutableListOf<TxtarEntry>()
 
             val children = psiFile.children
-            var i = 0
-
-            if (i < children.size && children[i].node.elementType == TxtarElementTypes.COMMENT_BLOCK) {
-                commentBlock = children[i].text
-                i++
-            }
-
-            while (i < children.size) {
-                val element = children[i]
-                if (element.node.elementType == TxtarElementTypes.HEADER) {
-                    val headerText = element.text
-                    i++
+            for (child in children) {
+                if (child.node.elementType == TxtarElementTypes.COMMENT_BLOCK) {
+                    commentBlock = child.text
+                } else if (child.node.elementType == TxtarElementTypes.FILE_ENTRY) {
+                    var headerText = ""
                     var contentText = ""
-
-                    // Look for content, skipping unknown elements
-                    while (i < children.size) {
-                        val type = children[i].node.elementType
-                        if (type == TxtarElementTypes.FILE_CONTENT) {
-                            contentText = children[i].text
-                            i++
-                            break
-                        } else if (type == TxtarElementTypes.HEADER) {
-                            // Next header found, so no content for this entry
-                            break
-                        } else {
-                            // Skip unknown elements (e.g. whitespace if any)
-                            i++
+                    var grandChild = child.firstChild
+                    while (grandChild != null) {
+                        if (grandChild.node.elementType == TxtarElementTypes.HEADER) {
+                            headerText = grandChild.text
+                        } else if (grandChild.node.elementType == TxtarElementTypes.FILE_CONTENT) {
+                            contentText = grandChild.text
                         }
+                        grandChild = grandChild.nextSibling
                     }
-                    entries.add(TxtarEntry(headerText, contentText))
-                } else {
-                    // Skip unknown elements
-                    i++
+                    if (headerText.isNotEmpty()) {
+                        entries.add(TxtarEntry(headerText, contentText))
+                    }
                 }
             }
             return Pair(commentBlock, entries)


### PR DESCRIPTION
The `ReorderFilesAction` was failing to correctly parse `txtar` files, causing `ReorderFilesActionTest` to fail. The issue was due to `ReorderFilesAction` expecting a flat list of `HEADER` and `FILE_CONTENT` elements as direct children of the `PsiFile`.

However, the `TxtarParserDefinition` (and the `txtar` grammar) creates a `FILE_ENTRY` composite element that wraps the `HEADER` token and the `FILE_CONTENT` composite element.

This PR updates the parsing logic in `ReorderFilesAction.kt` to:
1.  Iterate over the children of the `PsiFile`.
2.  Identify `FILE_ENTRY` elements.
3.  For each `FILE_ENTRY`, traverse its children (using `firstChild` and `nextSibling` for reliability, as `children` array was found to be unreliable for leaf tokens in this context) to extract the `HEADER` text and `FILE_CONTENT` text.

This change ensures that `ReorderFilesAction` correctly reconstructs the list of file entries, allowing the reordering functionality to work as expected.

Verified by running `ReorderFilesActionTest` and all other tests.

---
*PR created automatically by Jules for task [1983399124040527646](https://jules.google.com/task/1983399124040527646) started by @arran4*