### PR TITLE
Fix folding behavior and resize dark plugin icon

### DIFF
--- a/src/main/kotlin/com/example/txtar/TxtarFoldingBuilder.kt
+++ b/src/main/kotlin/com/example/txtar/TxtarFoldingBuilder.kt
@@ -5,6 +5,7 @@ import com.intellij.lang.folding.FoldingBuilderEx
 import com.intellij.lang.folding.FoldingDescriptor
 import com.intellij.openapi.editor.Document
 import com.intellij.openapi.project.DumbAware
+import com.intellij.openapi.util.TextRange
 import com.intellij.psi.PsiElement
 
 class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
@@ -16,7 +17,22 @@ class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
             val type = child.node.elementType
             if (type == TxtarElementTypes.COMMENT_BLOCK || type == TxtarElementTypes.FILE_ENTRY) {
                 if (child.textLength > 0) {
-                     descriptors.add(FoldingDescriptor(child, child.textRange))
+                     var range = child.textRange
+                     if (type == TxtarElementTypes.FILE_ENTRY) {
+                         var endOffset = range.endOffset
+                         while (endOffset > range.startOffset && endOffset <= document.textLength) {
+                             val char = document.charsSequence[endOffset - 1]
+                             if (char == '\n' || char == '\r') {
+                                 endOffset--
+                             } else {
+                                 break
+                             }
+                         }
+                         if (endOffset < range.endOffset) {
+                             range = TextRange(range.startOffset, endOffset)
+                         }
+                     }
+                     descriptors.add(FoldingDescriptor(child, range))
                 }
             }
             child = child.nextSibling
@@ -30,7 +46,7 @@ class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
         if (type == TxtarElementTypes.COMMENT_BLOCK) return "..."
         if (type == TxtarElementTypes.FILE_ENTRY) {
             val header = node.findChildByType(TxtarElementTypes.HEADER)
-            return header?.text ?: "..."
+            return header?.text?.trimEnd { it == '\n' || it == '\r' } ?: "..."
         }
         return null
     }

--- a/src/main/resources/META-INF/pluginIcon_dark.svg
+++ b/src/main/resources/META-INF/pluginIcon_dark.svg
@@ -1,10 +1,12 @@
 <svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
-  <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
-  <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
-  <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
-  <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
-  <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  <g transform="translate(4,4) scale(0.8)">
+    <rect width="40" height="40" rx="8" fill="url(#paint0_linear)"/>
+    <path d="M12 10V30H28V14L24 10H12Z" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M24 10V14H28" stroke="white" stroke-width="2" stroke-linejoin="round"/>
+    <path d="M15 20H18" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M22 20H25" stroke="white" stroke-width="1.5" stroke-linecap="round"/>
+    <path d="M15 24H25" stroke="white" stroke-width="1" stroke-opacity="0.6" stroke-linecap="round"/>
+  </g>
   <defs>
     <linearGradient id="paint0_linear" x1="0" y1="0" x2="40" y2="40" gradientUnits="userSpaceOnUse">
       <stop stop-color="#2D61B5"/>

--- a/testdata/folding/test_folding.txtar
+++ b/testdata/folding/test_folding.txtar
@@ -1,6 +1,4 @@
 <fold text='-- file --'>-- file --
 comment</fold>
-<fold text='-- file --'>
--- file --
-content
-</fold>
+<fold text='-- file --'>-- file --
+content</fold>


### PR DESCRIPTION
This PR addresses two issues:
1.  **Folding Behavior:** The folding logic for `FILE_ENTRY` was including trailing newlines, causing folded blocks to merge visually with subsequent blocks. The placeholder text also included newlines, causing rendering artifacts. The fix excludes trailing newlines from the folding range and trims them from the placeholder. The test data was also updated to be more precise.
2.  **Icon Sizing:** The `pluginIcon_dark.svg` was missing the required padding, causing it to appear "too big" compared to the standard icon. The fix applies the same scaling and translation transform as the light theme icon to ensure 4px padding. The light theme icon was verified to be correct.

---
*PR created automatically by Jules for task [12872636348043477919](https://jules.google.com/task/12872636348043477919) started by @arran4*