### PR TITLE
Fix folding test and overlapping folding regions

### DIFF
--- a/src/main/kotlin/com/arran4/txtar/TxtarFoldingBuilder.kt
+++ b/src/main/kotlin/com/arran4/txtar/TxtarFoldingBuilder.kt
@@ -42,19 +42,8 @@ class TxtarFoldingBuilder : FoldingBuilderEx(), DumbAware {
      */
     private fun expandToWholeLines(range: TextRange, document: Document): TextRange {
         val text = document.charsSequence
-        var start = range.startOffset.coerceIn(0, document.textLength)
+        val start = range.startOffset.coerceIn(0, document.textLength)
         var end = range.endOffset.coerceIn(0, document.textLength)
-
-        // include preceding line break (prefer grabbing "\r\n" together)
-        if (start > 0) {
-            val prev = text[start - 1]
-            if (prev == '\n') {
-                start--
-                if (start > 0 && text[start - 1] == '\r') start--
-            } else if (prev == '\r') {
-                start--
-            }
-        }
 
         // include following line break (prefer grabbing "\r\n" together)
         if (end < document.textLength) {

--- a/src/test/kotlin/com/example/txtar/FoldingTest.kt
+++ b/src/test/kotlin/com/example/txtar/FoldingTest.kt
@@ -9,6 +9,9 @@ class FoldingTest : BasePlatformTestCase() {
     }
 
     fun testFolding() {
-        myFixture.testFolding(testDataPath + "/folding/test_folding.txtar")
+        myFixture.testFolding(testDataPath + "/folding/test_folding.expected.txtar")
+
+        val incomingFile = File(testDataPath + "/folding/test_folding.incoming.txtar")
+        assertEquals(incomingFile.readText(), myFixture.editor.document.text)
     }
 }

--- a/testdata/folding/test_folding.expected.txtar
+++ b/testdata/folding/test_folding.expected.txtar
@@ -1,8 +1,5 @@
-<fold text='-- file1 --'>
--- file1 --
+<fold text='-- file1 --'>-- file1 --
 comment
-</fold>
-<fold text='-- file2 --'>
--- file2 --
+</fold><fold text='-- file2 --'>-- file2 --
 content
 </fold>


### PR DESCRIPTION
This PR fixes the failing `FoldingTest` by correcting the folding logic in `TxtarFoldingBuilder` and aligning the test data.

The `TxtarFoldingBuilder` previously expanded the folding range of a `FILE_ENTRY` to include the preceding line break. Since `FILE_ENTRY` elements typically include their trailing line break, this caused adjacent sibling entries to have overlapping folding regions (sharing the newline), which is invalid and caused test failures. The fix removes the start expansion logic.

The test data `testdata/folding/test_folding.expected.txtar` was updated to match the content of `testdata/folding/test_folding.incoming.txtar` exactly (including whitespace) and to use the correct folding regions (which now start at the header, excluding the preceding newline).

`FoldingTest.kt` was updated to verify the folding against the expected file and to ensure that the `incoming` file content matches the `expected` file content (stripped of tags), satisfying the user's request for conversion verification.

---
*PR created automatically by Jules for task [15824283579709530599](https://jules.google.com/task/15824283579709530599) started by @arran4*