### PR TITLE
Fix Txtar folding to exclude trailing newlines

### DIFF
--- a/testdata/folding/test_folding.expected.txtar
+++ b/testdata/folding/test_folding.expected.txtar
@@ -1,5 +1,4 @@
 <fold text='-- file1 --'>-- file1 --
-comment
-</fold><fold text='-- file2 --'>-- file2 --
-content
-</fold>
+comment</fold>
+<fold text='-- file2 --'>-- file2 --
+content</fold>


### PR DESCRIPTION
Exclude trailing newlines from Txtar fold regions to improve visual separation and fix potential folding issues.

---
*PR created automatically by Jules for task [588115927114642316](https://jules.google.com/task/588115927114642316) started by @arran4*