### PR TITLE
Add Marketplace Widget to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ The project is currently in active development. Basic support for the `txtar` fo
 
 ## Build and Install
 
+<div id="marketplace-install-widget"></div>
+<script src="https://plugins.jetbrains.com/assets/scripts/mp-widget.js"></script>
+<script>
+  MarketplaceWidget.setupMarketplaceWidget('install', 30286, "#marketplace-install-widget");
+</script>
+
 To build the plugin, run:
 
 ```bash


### PR DESCRIPTION
Inserted the marketplace widget script and target div into the 'Build and Install' section of README.md.

---
*PR created automatically by Jules for task [8550995424893646475](https://jules.google.com/task/8550995424893646475) started by @arran4*