### PR TITLE
Fix deprecated DialogWrapper constructor usage

### DIFF
--- a/src/main/kotlin/com/arran4/txtar/ReorderFilesDialog.kt
+++ b/src/main/kotlin/com/arran4/txtar/ReorderFilesDialog.kt
@@ -21,7 +21,7 @@ data class TxtarEntry(val headerText: String, val contentText: String) {
     }
 }
 
-class ReorderFilesDialog(project: Project, entries: List<TxtarEntry>) : DialogWrapper(project) {
+class ReorderFilesDialog(project: Project, entries: List<TxtarEntry>) : DialogWrapper(project, true) {
     private val model = CollectionListModel(entries)
     private val list = JBList(model)
 


### PR DESCRIPTION
This PR fixes a deprecated API usage in `ReorderFilesDialog` where the `DialogWrapper(Project)` constructor was used. This constructor is deprecated in recent IntelliJ Platform versions (including the target 2026.1 EAP) in favor of `DialogWrapper(Project, boolean)`. The change updates the code to use the recommended constructor, passing `true` for `canBeParent`, which preserves the original behavior.

This resolves the verification warning: "Deprecated constructor usage (1)".

---
*PR created automatically by Jules for task [17519936695701364024](https://jules.google.com/task/17519936695701364024) started by @arran4*