### PR TITLE
Update `untilBuild` to 262.*

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -41,8 +41,8 @@ tasks {
     }
 
     patchPluginXml {
-        sinceBuild.set("232")
-        untilBuild.set("262.*")
+        sinceBuild.set(providers.gradleProperty("pluginSinceBuild"))
+        untilBuild.set(providers.gradleProperty("pluginUntilBuild"))
     }
 
     signPlugin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -42,7 +42,7 @@ tasks {
 
     patchPluginXml {
         sinceBuild.set("232")
-        untilBuild.set("253.*")
+        untilBuild.set("262.*")
     }
 
     signPlugin {

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ pluginGroup=com.arran4.txtar
 pluginName=txtar-support
 pluginVersion=1.0.3
 pluginSinceBuild=232
-pluginUntilBuild=253.*
+pluginUntilBuild=262.*
 
 platformType=IC
 platformVersion=2023.2.5


### PR DESCRIPTION
Update `untilBuild` configuration in `build.gradle.kts` from `253.*` to `262.*`.
This is to ensure the plugin stays compatible with the upcoming JetBrains 261 IDE release.

---
*PR created automatically by Jules for task [3142109525257142680](https://jules.google.com/task/3142109525257142680) started by @arran4*