### PR TITLE
Add Txtar File to File > New menu

### DIFF
--- a/src/main/kotlin/com/arran4/txtar/CreateTxtarFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/CreateTxtarFileAction.kt
@@ -5,6 +5,16 @@ import com.intellij.ide.actions.CreateFileFromTemplateDialog
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDirectory
+import com.intellij.psi.PsiElement
+import com.intellij.openapi.fileChooser.FileChooser
+import com.intellij.openapi.fileChooser.FileChooserDescriptor
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.openapi.vfs.VfsUtil
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.application.ApplicationManager
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import java.io.IOException
 
 class CreateTxtarFileAction : CreateFileFromTemplateAction(
     "Txtar File",
@@ -18,5 +28,55 @@ class CreateTxtarFileAction : CreateFileFromTemplateAction(
 
     override fun getActionName(directory: PsiDirectory?, newName: String, templateName: String?): String {
         return "Create Txtar File $newName"
+    }
+
+    override fun postProcess(createdElement: PsiFile, templateName: String?, customProperties: Map<String, String>?) {
+        super.postProcess(createdElement, templateName, customProperties)
+
+        val project = createdElement.project
+        ApplicationManager.getApplication().invokeLater {
+            if (!createdElement.isValid) return@invokeLater
+
+            val descriptor = FileChooserDescriptor(true, true, false, false, false, true)
+            descriptor.title = "Select Files to Include"
+
+            val files = FileChooser.chooseFiles(descriptor, project, null)
+            if (files.isEmpty()) return@invokeLater
+
+            val content = StringBuilder()
+            // Add a newline to separate from template content if needed
+            content.append("\n")
+
+            for (file in files) {
+                processFile(file, "", content)
+            }
+
+            WriteCommandAction.runWriteCommandAction(project) {
+                val documentManager = PsiDocumentManager.getInstance(project)
+                val document = documentManager.getDocument(createdElement) ?: return@runWriteCommandAction
+                document.insertString(document.textLength, content.toString())
+                documentManager.commitDocument(document)
+            }
+        }
+    }
+
+    private fun processFile(file: VirtualFile, pathPrefix: String, content: StringBuilder) {
+        if (file.isDirectory) {
+            for (child in file.children) {
+                processFile(child, if (pathPrefix.isEmpty()) file.name else "$pathPrefix/${file.name}", content)
+            }
+        } else {
+            try {
+                val relativePath = if (pathPrefix.isEmpty()) file.name else "$pathPrefix/${file.name}"
+                content.append("-- $relativePath --\n")
+                // Use VfsUtil.loadText to read file content
+                content.append(VfsUtil.loadText(file))
+                if (!content.endsWith("\n")) {
+                    content.append("\n")
+                }
+            } catch (e: IOException) {
+                // Ignore errors reading files
+            }
+        }
     }
 }

--- a/src/main/kotlin/com/arran4/txtar/CreateTxtarFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/CreateTxtarFileAction.kt
@@ -12,8 +12,11 @@ import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.openapi.vfs.VfsUtil
 import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.application.ApplicationManager
+import com.intellij.openapi.progress.ProgressManager
+import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
+import com.intellij.openapi.diagnostic.Logger
 import java.io.IOException
 
 class CreateTxtarFileAction : CreateFileFromTemplateAction(
@@ -47,9 +50,11 @@ class CreateTxtarFileAction : CreateFileFromTemplateAction(
             // Add a newline to separate from template content if needed
             content.append("\n")
 
-            for (file in files) {
-                processFile(file, "", content)
-            }
+            ProgressManager.getInstance().runProcessWithProgressSynchronously({
+                for (file in files) {
+                    processFile(file, "", content)
+                }
+            }, "Reading Files to Append", true, project)
 
             WriteCommandAction.runWriteCommandAction(project) {
                 val documentManager = PsiDocumentManager.getInstance(project)
@@ -61,13 +66,13 @@ class CreateTxtarFileAction : CreateFileFromTemplateAction(
     }
 
     private fun processFile(file: VirtualFile, pathPrefix: String, content: StringBuilder) {
+        val relativePath = if (pathPrefix.isEmpty()) file.name else "$pathPrefix/${file.name}"
         if (file.isDirectory) {
             for (child in file.children) {
-                processFile(child, if (pathPrefix.isEmpty()) file.name else "$pathPrefix/${file.name}", content)
+                processFile(child, relativePath, content)
             }
         } else {
             try {
-                val relativePath = if (pathPrefix.isEmpty()) file.name else "$pathPrefix/${file.name}"
                 content.append("-- $relativePath --\n")
                 // Use VfsUtil.loadText to read file content
                 content.append(VfsUtil.loadText(file))
@@ -75,7 +80,7 @@ class CreateTxtarFileAction : CreateFileFromTemplateAction(
                     content.append("\n")
                 }
             } catch (e: IOException) {
-                // Ignore errors reading files
+                Logger.getInstance(CreateTxtarFileAction::class.java).warn("Error reading file to append", e)
             }
         }
     }

--- a/src/main/resources/fileTemplates/internal/Txtar File.txtar.ft
+++ b/src/main/resources/fileTemplates/internal/Txtar File.txtar.ft
@@ -1,1 +1,1 @@
--- file.txt --
+-- ${NAME}.txt --


### PR DESCRIPTION
This PR incorporates changes from a previous PR to add the missing "Txtar File" option to the "File > New" context menu, as well as giving the user the prompt to append the content of external files seamlessly. 
It also updates the file template internally to use the `${NAME}` variable.

---
*PR created automatically by Jules for task [3766990585751024345](https://jules.google.com/task/3766990585751024345) started by @arran4*