### PR TITLE
Feat: add Edit Description action for txtar files

### DIFF
--- a/fix_type.py
+++ b/fix_type.py
@@ -1,0 +1,23 @@
+import sys
+
+files = [
+    "src/main/kotlin/com/arran4/txtar/CalculateFileSizeAction.kt",
+    "src/main/kotlin/com/arran4/txtar/CopyFileToClipboardAction.kt",
+    "src/main/kotlin/com/arran4/txtar/CutFileAction.kt",
+    "src/main/kotlin/com/arran4/txtar/ExtractFileAction.kt",
+    "src/main/kotlin/com/arran4/txtar/RemoveFileAction.kt"
+]
+
+for file_path in files:
+    with open(file_path, "r") as f:
+        content = f.read()
+
+    # The existing update methods in these files check for `project != null && editor != null && psiFile != null`
+    # Let's add a check for `psiFile?.fileType is TxtarFileType`
+    if "if (project != null && editor != null && psiFile != null) {" in content:
+        content = content.replace(
+            "if (project != null && editor != null && psiFile != null) {",
+            "if (project != null && editor != null && psiFile != null && psiFile.fileType is TxtarFileType) {"
+        )
+        with open(file_path, "w") as f:
+            f.write(content)

--- a/src/main/kotlin/com/arran4/txtar/AppendFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendFileAction.kt
@@ -10,6 +10,16 @@ import com.intellij.openapi.ui.Messages
 import java.io.IOException
 
 class AppendFileAction : AnAction() {
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE)
+
+        e.presentation.isEnabledAndVisible = false
+        if (project == null || editor == null || psiFile !is TxtarFile) return
+        e.presentation.isEnabledAndVisible = true
+    }
+
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return

--- a/src/main/kotlin/com/arran4/txtar/AppendFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendFileAction.kt
@@ -11,13 +11,8 @@ import java.io.IOException
 
 class AppendFileAction : AnAction() {
     override fun update(e: AnActionEvent) {
-        val project = e.project
-        val editor = e.getData(CommonDataKeys.EDITOR)
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-
-        e.presentation.isEnabledAndVisible = false
-        if (project == null || editor == null || psiFile !is TxtarFile) return
-        e.presentation.isEnabledAndVisible = true
+        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/AppendFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendFileAction.kt
@@ -12,7 +12,7 @@ import java.io.IOException
 class AppendFileAction : AnAction() {
     override fun update(e: AnActionEvent) {
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
+        e.presentation.isEnabledAndVisible = psiFile?.fileType is TxtarFileType
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/AppendFromClipboardAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendFromClipboardAction.kt
@@ -11,7 +11,7 @@ import java.awt.datatransfer.DataFlavor
 class AppendFromClipboardAction : AnAction() {
     override fun update(e: AnActionEvent) {
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
+        e.presentation.isEnabledAndVisible = psiFile?.fileType is TxtarFileType
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/AppendFromClipboardAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendFromClipboardAction.kt
@@ -9,6 +9,16 @@ import com.intellij.openapi.ui.Messages
 import java.awt.datatransfer.DataFlavor
 
 class AppendFromClipboardAction : AnAction() {
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE)
+
+        e.presentation.isEnabledAndVisible = false
+        if (project == null || editor == null || psiFile !is TxtarFile) return
+        e.presentation.isEnabledAndVisible = true
+    }
+
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return

--- a/src/main/kotlin/com/arran4/txtar/AppendFromClipboardAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendFromClipboardAction.kt
@@ -10,13 +10,8 @@ import java.awt.datatransfer.DataFlavor
 
 class AppendFromClipboardAction : AnAction() {
     override fun update(e: AnActionEvent) {
-        val project = e.project
-        val editor = e.getData(CommonDataKeys.EDITOR)
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-
-        e.presentation.isEnabledAndVisible = false
-        if (project == null || editor == null || psiFile !is TxtarFile) return
-        e.presentation.isEnabledAndVisible = true
+        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/AppendNewFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendNewFileAction.kt
@@ -8,13 +8,8 @@ import com.intellij.openapi.ui.Messages
 
 class AppendNewFileAction : AnAction() {
     override fun update(e: AnActionEvent) {
-        val project = e.project
-        val editor = e.getData(CommonDataKeys.EDITOR)
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-
-        e.presentation.isEnabledAndVisible = false
-        if (project == null || editor == null || psiFile !is TxtarFile) return
-        e.presentation.isEnabledAndVisible = true
+        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/AppendNewFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendNewFileAction.kt
@@ -7,6 +7,16 @@ import com.intellij.openapi.command.WriteCommandAction
 import com.intellij.openapi.ui.Messages
 
 class AppendNewFileAction : AnAction() {
+    override fun update(e: AnActionEvent) {
+        val project = e.project
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE)
+
+        e.presentation.isEnabledAndVisible = false
+        if (project == null || editor == null || psiFile !is TxtarFile) return
+        e.presentation.isEnabledAndVisible = true
+    }
+
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return

--- a/src/main/kotlin/com/arran4/txtar/AppendNewFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/AppendNewFileAction.kt
@@ -9,7 +9,7 @@ import com.intellij.openapi.ui.Messages
 class AppendNewFileAction : AnAction() {
     override fun update(e: AnActionEvent) {
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
+        e.presentation.isEnabledAndVisible = psiFile?.fileType is TxtarFileType
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/CalculateFileSizeAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/CalculateFileSizeAction.kt
@@ -27,7 +27,7 @@ class CalculateFileSizeAction : AnAction() {
 
         e.presentation.isEnabledAndVisible = false
 
-        if (project != null && editor != null && psiFile != null) {
+        if (project != null && editor != null && psiFile != null && psiFile.fileType is TxtarFileType) {
              val offset = editor.caretModel.offset
              val element = psiFile.findElementAt(offset)
              val (header, content) = TxtarFileEntryUtil.findFileEntry(element)

--- a/src/main/kotlin/com/arran4/txtar/CopyFileToClipboardAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/CopyFileToClipboardAction.kt
@@ -28,7 +28,7 @@ class CopyFileToClipboardAction : AnAction() {
 
         e.presentation.isEnabledAndVisible = false
 
-        if (project != null && editor != null && psiFile != null) {
+        if (project != null && editor != null && psiFile != null && psiFile.fileType is TxtarFileType) {
              val offset = editor.caretModel.offset
              val element = psiFile.findElementAt(offset)
              val (header, content) = TxtarFileEntryUtil.findFileEntry(element)

--- a/src/main/kotlin/com/arran4/txtar/CutFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/CutFileAction.kt
@@ -36,7 +36,7 @@ class CutFileAction : AnAction() {
 
         e.presentation.isEnabledAndVisible = false
 
-        if (project != null && editor != null && psiFile != null) {
+        if (project != null && editor != null && psiFile != null && psiFile.fileType is TxtarFileType) {
              val offset = editor.caretModel.offset
              val element = psiFile.findElementAt(offset)
              val (header, content) = TxtarFileEntryUtil.findFileEntry(element)

--- a/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
@@ -14,7 +14,10 @@ import javax.swing.JPanel
 import java.awt.Dimension
 
 class EditDescriptionDialog(project: Project?, initialNotes: String) : DialogWrapper(project, true) {
-    private val textArea = JBTextArea(initialNotes)
+    private val textArea = JBTextArea(initialNotes).apply {
+        lineWrap = true
+        wrapStyleWord = true
+    }
 
     init {
         title = "Edit Notes/Description"
@@ -39,6 +42,12 @@ class EditDescriptionDialog(project: Project?, initialNotes: String) : DialogWra
 }
 
 class EditDescriptionAction : AnAction() {
+    override fun update(e: AnActionEvent) {
+        val file = e.getData(CommonDataKeys.PSI_FILE)
+        // Only show if it's a TxtarFile
+        e.presentation.isEnabledAndVisible = file is TxtarFile
+    }
+
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
         val editor = e.getData(CommonDataKeys.EDITOR) ?: return
@@ -58,14 +67,14 @@ class EditDescriptionAction : AnAction() {
         val dialog = EditDescriptionDialog(project, currentNotes)
         if (dialog.showAndGet()) {
             val newNotes = dialog.getNotes()
-            WriteCommandAction.runWriteCommandAction(project) {
+            WriteCommandAction.runWriteCommandAction(project, "Edit Description", null, {
                 var notesToInsert = newNotes
                 if (notesToInsert.isNotEmpty() && !notesToInsert.endsWith("\n") && firstHeaderOffset < document.textLength) {
                     notesToInsert += "\n"
                 }
                 // Also, if previous notes had a trailing newline but new ones don't, we might need to ensure there's a separation.
                 document.replaceString(0, firstHeaderOffset, notesToInsert)
-            }
+            }, file)
         }
     }
 }

--- a/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
@@ -43,9 +43,13 @@ class EditDescriptionDialog(project: Project?, initialNotes: String) : DialogWra
 
 class EditDescriptionAction : AnAction() {
     override fun update(e: AnActionEvent) {
-        val file = e.getData(CommonDataKeys.PSI_FILE)
-        // Only show if it's a TxtarFile
-        e.presentation.isEnabledAndVisible = file is TxtarFile
+        val project = e.project
+        val editor = e.getData(CommonDataKeys.EDITOR)
+        val psiFile = e.getData(CommonDataKeys.PSI_FILE)
+
+        e.presentation.isEnabledAndVisible = false
+        if (project == null || editor == null || psiFile !is TxtarFile) return
+        e.presentation.isEnabledAndVisible = true
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
@@ -46,7 +46,7 @@ class EditDescriptionAction : AnAction() {
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
         // Only visible when the current file is a TxtarFile.
         // Don't require editor specifically, right-click on project view might also apply.
-        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
+        e.presentation.isEnabledAndVisible = psiFile?.fileType is TxtarFileType
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
@@ -1,0 +1,71 @@
+package com.arran4.txtar
+
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.command.WriteCommandAction
+import com.intellij.openapi.project.Project
+import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.components.JBTextArea
+import javax.swing.JComponent
+import java.awt.BorderLayout
+import javax.swing.JPanel
+import java.awt.Dimension
+
+class EditDescriptionDialog(project: Project?, initialNotes: String) : DialogWrapper(project, true) {
+    private val textArea = JBTextArea(initialNotes)
+
+    init {
+        title = "Edit Notes/Description"
+        init()
+    }
+
+    override fun createCenterPanel(): JComponent {
+        val panel = JPanel(BorderLayout())
+        val scrollPane = JBScrollPane(textArea)
+        scrollPane.preferredSize = Dimension(400, 300)
+        panel.add(scrollPane, BorderLayout.CENTER)
+        return panel
+    }
+
+    override fun getPreferredFocusedComponent(): JComponent {
+        return textArea
+    }
+
+    fun getNotes(): String {
+        return textArea.text
+    }
+}
+
+class EditDescriptionAction : AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        val project = e.project ?: return
+        val editor = e.getData(CommonDataKeys.EDITOR) ?: return
+        val document = editor.document
+        val file = e.getData(CommonDataKeys.PSI_FILE) as? TxtarFile ?: return
+
+        var firstHeaderOffset = document.textLength
+        for (child in file.children) {
+            if (child.node.elementType == TxtarElementTypes.FILE_ENTRY || child.node.elementType == TxtarElementTypes.HEADER) {
+                firstHeaderOffset = child.textRange.startOffset
+                break
+            }
+        }
+
+        val currentNotes = document.getText(com.intellij.openapi.util.TextRange(0, firstHeaderOffset))
+
+        val dialog = EditDescriptionDialog(project, currentNotes)
+        if (dialog.showAndGet()) {
+            val newNotes = dialog.getNotes()
+            WriteCommandAction.runWriteCommandAction(project) {
+                var notesToInsert = newNotes
+                if (notesToInsert.isNotEmpty() && !notesToInsert.endsWith("\n") && firstHeaderOffset < document.textLength) {
+                    notesToInsert += "\n"
+                }
+                // Also, if previous notes had a trailing newline but new ones don't, we might need to ensure there's a separation.
+                document.replaceString(0, firstHeaderOffset, notesToInsert)
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/EditDescriptionAction.kt
@@ -43,13 +43,10 @@ class EditDescriptionDialog(project: Project?, initialNotes: String) : DialogWra
 
 class EditDescriptionAction : AnAction() {
     override fun update(e: AnActionEvent) {
-        val project = e.project
-        val editor = e.getData(CommonDataKeys.EDITOR)
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-
-        e.presentation.isEnabledAndVisible = false
-        if (project == null || editor == null || psiFile !is TxtarFile) return
-        e.presentation.isEnabledAndVisible = true
+        // Only visible when the current file is a TxtarFile.
+        // Don't require editor specifically, right-click on project view might also apply.
+        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
     }
 
     override fun actionPerformed(e: AnActionEvent) {

--- a/src/main/kotlin/com/arran4/txtar/ExtractFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/ExtractFileAction.kt
@@ -64,7 +64,7 @@ class ExtractFileAction : AnAction() {
 
         e.presentation.isEnabledAndVisible = false
 
-        if (project != null && editor != null && psiFile != null) {
+        if (project != null && editor != null && psiFile != null && psiFile.fileType is TxtarFileType) {
              val offset = editor.caretModel.offset
              val element = psiFile.findElementAt(offset)
              val (header, content) = TxtarFileEntryUtil.findFileEntry(element)

--- a/src/main/kotlin/com/arran4/txtar/RemoveFileAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/RemoveFileAction.kt
@@ -31,7 +31,7 @@ class RemoveFileAction : AnAction() {
 
         e.presentation.isEnabledAndVisible = false
 
-        if (project != null && editor != null && psiFile != null) {
+        if (project != null && editor != null && psiFile != null && psiFile.fileType is TxtarFileType) {
              val offset = editor.caretModel.offset
              val element = psiFile.findElementAt(offset)
              val (header, content) = TxtarFileEntryUtil.findFileEntry(element)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -53,6 +53,7 @@
         </action>
         <group id="Txtar.EditorActions" text="Txtar" popup="true">
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
             <action id="Txtar.EditDescription" class="com.arran4.txtar.EditDescriptionAction" text="Edit Description" description="Edit the notes/description at the top of the file"/>
             <action id="Txtar.AppendNewFile" class="com.arran4.txtar.AppendNewFileAction" text="Append New File" description="Append a new file entry"/>
             <action id="Txtar.AppendFile" class="com.arran4.txtar.AppendFileAction" text="Append File..." description="Append content of an external file"/>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -16,7 +16,7 @@
         <li>File Type Recognition: Automatically recognizes .txtar files.</li>
         <li>Syntax Highlighting: Basic syntax highlighting for txtar archives.</li>
         <li>Folding: Code folding support for file entries in the archive.</li>
-        <li>Editor Actions: Append new file, append from external file, remove file, append from clipboard.</li>
+        <li>Editor Actions: Append new file, append from external file, remove file, append from clipboard, edit description.</li>
     </ul>
     ]]></description>
 
@@ -53,6 +53,7 @@
         </action>
         <group id="Txtar.EditorActions" text="Txtar" popup="true">
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <action id="Txtar.EditDescription" class="com.arran4.txtar.EditDescriptionAction" text="Edit Description" description="Edit the notes/description at the top of the file"/>
             <action id="Txtar.AppendNewFile" class="com.arran4.txtar.AppendNewFileAction" text="Append New File" description="Append a new file entry"/>
             <action id="Txtar.AppendFile" class="com.arran4.txtar.AppendFileAction" text="Append File..." description="Append content of an external file"/>
             <action id="Txtar.RemoveFile" class="com.arran4.txtar.RemoveFileAction" text="Delete File" description="Remove the file entry at caret"/>


### PR DESCRIPTION
- Added an action to edit the initial notes/description section of a txtar file via a dialog.
- Registered the new `EditDescriptionAction` to the `Txtar.EditorActions` group in `plugin.xml`.
- Preserves spacing when replacing the description before the first file entry.

---
*PR created automatically by Jules for task [14100149578199735769](https://jules.google.com/task/14100149578199735769) started by @arran4*