### PR TITLE
Fix duplicate merge.jar by replacing slash in version string with hyphen

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 group = "com.arran4.txtar"
 val pluginVersion: String by project
-version = System.getenv("GITHUB_REF_NAME")?.removePrefix("v") ?: pluginVersion
+version = System.getenv("GITHUB_REF_NAME")?.removePrefix("v")?.replace("/", "-") ?: pluginVersion
 
 repositories {
     mavenCentral()

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
 
 group = "com.arran4.txtar"
 val pluginVersion: String by project
-version = System.getenv("GITHUB_REF_NAME")?.removePrefix("v")?.replace("/", "-") ?: pluginVersion
+version = providers.environmentVariable("GITHUB_REF_NAME").getOrNull()?.removePrefix("v")?.replace("/", "-") ?: pluginVersion
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
Fix duplicate merge.jar by replacing slash in version string with hyphen

When building from a PR or branch with a slash in the name (e.g., `34/merge`), the `GITHUB_REF_NAME` evaluates to a string containing a `/`. In `build.gradle.kts`, this string is directly used as the `version`. Because `/` is a directory separator, the packaging logic creates nested directories inside the build outputs (`txtar-support-34/merge.jar`) instead of standard file names (`txtar-support-34-merge.jar`). This leads to duplicate entry errors during the `buildPlugin` phase (`merge.jar is a duplicate but no duplicate handling strategy has been set`).

This fix sanitizes the version string by replacing all `/` with `-`, ensuring that the generated jar file is correctly named and avoiding directory traversal issues during build.

---
*PR created automatically by Jules for task [1881784600754338754](https://jules.google.com/task/1881784600754338754) started by @arran4*