### PR TITLE
Move Txtar File option down the New File list

### DIFF
--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -41,7 +41,7 @@
 
     <actions>
         <action id="Txtar.NewFile" class="com.arran4.txtar.CreateTxtarFileAction" text="Txtar File" description="Create new Txtar file">
-            <add-to-group group-id="NewGroup" anchor="before" relative-to-action="NewFile"/>
+            <add-to-group group-id="NewGroup" anchor="last"/>
         </action>
         <group id="Txtar.EditorActions" text="Txtar" popup="true">
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>


### PR DESCRIPTION
Moved the "Txtar File" option to be anchored "last" in the "NewGroup" so that it appears closer to the bottom instead of before "NewFile", as requested by the user.

---
*PR created automatically by Jules for task [15838363205459522350](https://jules.google.com/task/15838363205459522350) started by @arran4*