### PR TITLE
Show Txtar edit menu in project view

### DIFF
--- a/src/main/kotlin/com/arran4/txtar/CalculateFileSizeAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/CalculateFileSizeAction.kt
@@ -25,9 +25,14 @@ class CalculateFileSizeAction : AnAction() {
         val editor = e.getData(CommonDataKeys.EDITOR)
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
 
+        if (editor == null) {
+            e.presentation.isEnabledAndVisible = false
+            return
+        }
+
         e.presentation.isEnabledAndVisible = false
 
-        if (project != null && editor != null && psiFile != null) {
+        if (project != null && psiFile != null) {
              val offset = editor.caretModel.offset
              val element = psiFile.findElementAt(offset)
              val (header, content) = TxtarFileEntryUtil.findFileEntry(element)

--- a/src/main/kotlin/com/arran4/txtar/EditTxtarEntriesAction.kt
+++ b/src/main/kotlin/com/arran4/txtar/EditTxtarEntriesAction.kt
@@ -10,12 +10,19 @@ class EditTxtarEntriesAction : AnAction() {
 
     override fun update(e: AnActionEvent) {
         val psiFile = e.getData(CommonDataKeys.PSI_FILE)
-        e.presentation.isEnabledAndVisible = psiFile is TxtarFile
+        val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE)
+        val isTxtar = psiFile?.fileType == TxtarFileType.INSTANCE || virtualFile?.extension == "txtar"
+        e.presentation.isEnabledAndVisible = isTxtar
     }
 
     override fun actionPerformed(e: AnActionEvent) {
         val project = e.project ?: return
-        val psiFile = e.getData(CommonDataKeys.PSI_FILE) as? TxtarFile ?: return
+        var psiFile = e.getData(CommonDataKeys.PSI_FILE)
+        if (psiFile == null) {
+            val virtualFile = e.getData(CommonDataKeys.VIRTUAL_FILE) ?: return
+            psiFile = com.intellij.psi.PsiManager.getInstance(project).findFile(virtualFile)
+        }
+        if (psiFile == null) return
 
         // 1. Parse
         val (description, entries) = parseFile(psiFile)

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -43,10 +43,10 @@
         <action id="Txtar.NewFile" class="com.arran4.txtar.CreateTxtarFileAction" text="Txtar File" description="Create new Txtar file">
             <add-to-group group-id="NewGroup" anchor="last"/>
         </action>
-        <group id="Txtar.EditorActions" text="Txtar" popup="true">
+        <group id="Txtar.EditorActions" text="Txtar" popup="false">
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
             <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
-            <action id="Txtar.EditTxtarEntries" class="com.arran4.txtar.EditTxtarEntriesAction" text="Edit Txtar Entries..." description="Edit txtar entries and description"/>
+            <action id="Txtar.EditTxtarEntries" class="com.arran4.txtar.EditTxtarEntriesAction" text="Edit Txtar" description="Edit txtar entries and description"/>
             <action id="Txtar.CalculateFileSize" class="com.arran4.txtar.CalculateFileSizeAction" text="Calculate File Size" description="Calculate size of file"/>
         </group>
     </actions>

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -45,6 +45,7 @@
         </action>
         <group id="Txtar.EditorActions" text="Txtar" popup="true">
             <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+            <add-to-group group-id="ProjectViewPopupMenu" anchor="last"/>
             <action id="Txtar.EditTxtarEntries" class="com.arran4.txtar.EditTxtarEntriesAction" text="Edit Txtar Entries..." description="Edit txtar entries and description"/>
             <action id="Txtar.CalculateFileSize" class="com.arran4.txtar.CalculateFileSizeAction" text="Calculate File Size" description="Calculate size of file"/>
         </group>

--- a/src/test/kotlin/com/arran4/txtar/EditTxtarEntriesActionTest.kt
+++ b/src/test/kotlin/com/arran4/txtar/EditTxtarEntriesActionTest.kt
@@ -1,0 +1,27 @@
+package com.arran4.txtar
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.openapi.actionSystem.CommonDataKeys
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.Presentation
+import com.intellij.openapi.actionSystem.DataContext
+
+class EditTxtarEntriesActionTest : BasePlatformTestCase() {
+    fun testActionIsEnabledOnTxtarFile() {
+        val file = myFixture.configureByText(TxtarFileType.INSTANCE, "This is a test\n")
+        val action = EditTxtarEntriesAction()
+
+        val presentation = Presentation()
+        val event = AnActionEvent.createFromDataContext("Place", presentation, DataContext { dataId ->
+            when (dataId) {
+                CommonDataKeys.PSI_FILE.name -> file
+                CommonDataKeys.PROJECT.name -> project
+                else -> null
+            }
+        })
+
+        action.update(event)
+
+        assertTrue("Action should be enabled and visible", presentation.isEnabledAndVisible)
+    }
+}


### PR DESCRIPTION
Makes the "Edit Txtar Entries..." action available when right-clicking `.txtar` files in the Project tool window. Previously, it was only available inside the editor and appeared grayed out when triggered from the project view.

---
*PR created automatically by Jules for task [4968156106534765118](https://jules.google.com/task/4968156106534765118) started by @arran4*