### PR TITLE
Fix CI NPE during publishPlugin by passing key content instead of file paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -288,12 +288,14 @@ jobs:
       - name: Publish to JetBrains Marketplace
         env:
           PUBLISH_TOKEN: ${{ secrets.JB_PUBLISH_TOKEN }}
-          CERTIFICATE_CHAIN: /tmp/chain.crt
-          PRIVATE_KEY: /tmp/private.pem
+          PRIVATE_KEY_PASSWORD: ${{ secrets.JB_PRIVATE_KEY_PASSWORD }}
           # The publish plugin task relies on GITHUB_REF_NAME by default.
           # We need to simulate it for manual releases or just use it.
           GITHUB_REF_NAME: ${{ needs.prepare-release-tag.outputs.release_tag || github.ref_name }}
-        run: ./gradlew publishPlugin
+        run: |
+          export CERTIFICATE_CHAIN="$(cat /tmp/chain.crt)"
+          export PRIVATE_KEY="$(cat /tmp/private.pem)"
+          ./gradlew publishPlugin
 
   manual-gh-release:
     name: Manual release creation


### PR DESCRIPTION
Fix CI NPE during publishPlugin by passing key content instead of file paths

The gradle-intellij-plugin expects the literal string content of the private key and certificate chain in the `CERTIFICATE_CHAIN` and `PRIVATE_KEY` environment variables, rather than the paths to the files. When paths were passed, it resulted in a NullPointerException during parsing. This commit exports the extracted content from those files directly into the environment variables before invoking `./gradlew publishPlugin`.

---
*PR created automatically by Jules for task [11080994724249142209](https://jules.google.com/task/11080994724249142209) started by @arran4*