### PR TITLE
support language injections in txtar files

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,9 @@ intellij {
     pluginName.set("txtar-support")
     version.set("2023.2.5")
     type.set("IC") // Target IDE Platform
-    plugins.set(listOf(/* Plugin Dependencies */))
+    plugins.set(listOf(
+        "org.intellij.intelliLang",
+    ))
 }
 
 configurations {

--- a/src/main/kotlin/com/arran4/txtar/FileElement.kt
+++ b/src/main/kotlin/com/arran4/txtar/FileElement.kt
@@ -1,0 +1,34 @@
+package com.arran4.txtar
+
+import com.intellij.extapi.psi.ASTWrapperPsiElement
+import com.intellij.lang.ASTNode
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.AbstractElementManipulator
+import com.intellij.psi.ElementManipulators
+import com.intellij.psi.LiteralTextEscaper
+import com.intellij.psi.PsiLanguageInjectionHost
+import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
+
+class FileElement(node: ASTNode) : ASTWrapperPsiElement(node),  PsiLanguageInjectionHost, InjectionBackgroundSuppressor {
+    override fun isValidHost(): Boolean {
+        return true
+    }
+
+    override fun updateText(text: String): PsiLanguageInjectionHost? {
+        return ElementManipulators.handleContentChange(this, text)
+    }
+
+    override fun createLiteralTextEscaper(): LiteralTextEscaper<out PsiLanguageInjectionHost?> {
+        return LiteralTextEscaper.createSimple(this)
+    }
+    internal class Manipulator: AbstractElementManipulator<FileElement>() {
+        override fun handleContentChange(
+            element: FileElement,
+            range: TextRange,
+            newContent: String?
+        ): FileElement? {
+            // no manipulation necessary
+            return element
+        }
+    }
+}

--- a/src/main/kotlin/com/arran4/txtar/FileElement.kt
+++ b/src/main/kotlin/com/arran4/txtar/FileElement.kt
@@ -9,7 +9,7 @@ import com.intellij.psi.LiteralTextEscaper
 import com.intellij.psi.PsiLanguageInjectionHost
 import com.intellij.psi.impl.source.tree.injected.InjectionBackgroundSuppressor
 
-class FileElement(node: ASTNode) : ASTWrapperPsiElement(node),  PsiLanguageInjectionHost, InjectionBackgroundSuppressor {
+class FileElement(node: ASTNode) : ASTWrapperPsiElement(node), PsiLanguageInjectionHost, InjectionBackgroundSuppressor {
     override fun isValidHost(): Boolean {
         return true
     }
@@ -21,14 +21,24 @@ class FileElement(node: ASTNode) : ASTWrapperPsiElement(node),  PsiLanguageInjec
     override fun createLiteralTextEscaper(): LiteralTextEscaper<out PsiLanguageInjectionHost?> {
         return LiteralTextEscaper.createSimple(this)
     }
-    internal class Manipulator: AbstractElementManipulator<FileElement>() {
+
+    internal class Manipulator : AbstractElementManipulator<FileElement>() {
         override fun handleContentChange(
             element: FileElement,
             range: TextRange,
             newContent: String?
         ): FileElement? {
-            // no manipulation necessary
-            return element
+            val oldText = element.text
+            val newText =
+                oldText.substring(0, range.startOffset) + (newContent ?: "") + oldText.substring(range.endOffset)
+            val dummyFile = com.intellij.psi.PsiFileFactory.getInstance(element.project)
+                .createFileFromText("dummy.txtar", TxtarLanguage.INSTANCE, "-- dummy --\n$newText")
+            val newElement = com.intellij.psi.util.PsiTreeUtil.findChildOfType(dummyFile, FileElement::class.java)
+            return if (newElement != null) {
+                element.replace(newElement) as FileElement
+            } else {
+                element
+            }
         }
     }
 }

--- a/src/main/kotlin/com/arran4/txtar/FileInjector.kt
+++ b/src/main/kotlin/com/arran4/txtar/FileInjector.kt
@@ -1,0 +1,29 @@
+package com.arran4.txtar
+
+import com.intellij.lang.Language
+import com.intellij.lang.LanguageParserDefinitions
+import com.intellij.lang.LanguageUtil
+import com.intellij.lang.injection.general.Injection
+import com.intellij.lang.injection.general.LanguageInjectionContributor
+import com.intellij.lang.injection.general.SimpleInjection
+import com.intellij.openapi.fileTypes.FileTypeManager
+import com.intellij.psi.PsiElement
+import com.intellij.psi.util.elementType
+
+class FileInjector : LanguageInjectionContributor {
+    override fun getInjection(context: PsiElement): Injection? {
+        val type = context.elementType ?: return null
+        if (type != TxtarElementTypes.FILE_CONTENT) return null
+        val header = context.prevSibling.takeIf { it.elementType == TxtarElementTypes.HEADER } ?: return null
+        val text = header.text ?: return null
+        val stripped = text.trim().removePrefix("-- ").removeSuffix(" --").trim()
+        val idx = stripped.lastIndexOf('.')
+        if (idx == -1) {
+            return null
+        }
+        val extension = stripped.substring(idx + 1)
+        val fileType = FileTypeManager.getInstance().getFileTypeByExtension(extension)
+        val language =  LanguageUtil.getFileTypeLanguage(fileType) ?: return null
+        return SimpleInjection(language, "", "", null)
+    }
+}

--- a/src/main/kotlin/com/arran4/txtar/FileInjector.kt
+++ b/src/main/kotlin/com/arran4/txtar/FileInjector.kt
@@ -1,7 +1,5 @@
 package com.arran4.txtar
 
-import com.intellij.lang.Language
-import com.intellij.lang.LanguageParserDefinitions
 import com.intellij.lang.LanguageUtil
 import com.intellij.lang.injection.general.Injection
 import com.intellij.lang.injection.general.LanguageInjectionContributor
@@ -14,15 +12,13 @@ class FileInjector : LanguageInjectionContributor {
     override fun getInjection(context: PsiElement): Injection? {
         val type = context.elementType ?: return null
         if (type != TxtarElementTypes.FILE_CONTENT) return null
-        val header = context.prevSibling.takeIf { it.elementType == TxtarElementTypes.HEADER } ?: return null
+        val header = context.parent.firstChild.takeIf { it.elementType == TxtarElementTypes.HEADER } ?: return null
         val text = header.text ?: return null
         val stripped = text.trim().removePrefix("-- ").removeSuffix(" --").trim()
-        val idx = stripped.lastIndexOf('.')
-        if (idx == -1) {
-            return null
-        }
-        val extension = stripped.substring(idx + 1)
-        val fileType = FileTypeManager.getInstance().getFileTypeByExtension(extension)
+        val fileName = stripped.substringAfterLast('/')
+        val extension = stripped.substringAfterLast('.')
+        val ftManager = FileTypeManager.getInstance()
+        val fileType = ftManager.findFileTypeByName(fileName) ?: ftManager.getFileTypeByExtension(extension)
         val language =  LanguageUtil.getFileTypeLanguage(fileType) ?: return null
         return SimpleInjection(language, "", "", null)
     }

--- a/src/main/kotlin/com/arran4/txtar/TxtarParserDefinition.kt
+++ b/src/main/kotlin/com/arran4/txtar/TxtarParserDefinition.kt
@@ -59,7 +59,12 @@ class TxtarParserDefinition : ParserDefinition {
 
     override fun getStringLiteralElements(): TokenSet = TokenSet.EMPTY
 
-    override fun createElement(node: ASTNode): PsiElement = ASTWrapperPsiElement(node)
+    override fun createElement(node: ASTNode): PsiElement {
+        if (node.elementType == TxtarElementTypes.FILE_CONTENT) {
+            return FileElement(node)
+        }
+        return ASTWrapperPsiElement(node)
+    }
 
     override fun createFile(viewProvider: FileViewProvider): PsiFile = TxtarFile(viewProvider)
 }

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -68,6 +68,9 @@
             <className>com.arran4.txtar.CreateNewEmptyFileIntention</className>
             <category>Txtar</category>
         </intentionAction>
+        <languageInjectionContributor language="Txtar" implementationClass="com.arran4.txtar.FileInjector"/>
+        <lang.elementManipulator forClass="com.arran4.txtar.FileElement"
+                                 implementationClass="com.arran4.txtar.FileElement$Manipulator"/>
     </extensions>
     <actions>
         <action id="Txtar.NewFile" class="com.arran4.txtar.CreateTxtarFileAction" text="Txtar File" description="Create new Txtar file">

--- a/src/test/kotlin/com/example/txtar/LanguageInjectionTest.kt
+++ b/src/test/kotlin/com/example/txtar/LanguageInjectionTest.kt
@@ -1,0 +1,28 @@
+package com.example.txtar
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+import com.intellij.testFramework.fixtures.InjectionTestFixture
+import com.intellij.testFramework.fixtures.injectionForHost
+import java.io.File
+
+class LanguageInjectionTest : BasePlatformTestCase() {
+    override fun getTestDataPath(): String {
+        return File("testdata").absolutePath
+    }
+
+    fun testLanguageInjection() {
+        myFixture.configureByText("test.txtar", """
+            -- foo.json --
+            { "foo": "bar" }
+            
+            -- foo.xml --
+            <bar>foo</bar>
+        """.trimIndent())
+        val injectionFixture = InjectionTestFixture(myFixture)
+        injectionFixture
+            .assertInjected(
+                injectionForHost("{ \"foo\": \"bar\" }\n\n").hasLanguage("JSON"),
+                injectionForHost("<bar>foo</bar>").hasLanguage("XML"),
+            )
+    }
+}

--- a/src/test/kotlin/com/example/txtar/LanguageInjectionTest.kt
+++ b/src/test/kotlin/com/example/txtar/LanguageInjectionTest.kt
@@ -1,4 +1,4 @@
-package com.example.txtar
+package com.arran4.txtar
 
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.testFramework.fixtures.InjectionTestFixture


### PR DESCRIPTION
Hi @arran4,

not sure if you are interested in this PR, please close if you don't want it. I've added support for language injections to your plugin so that files in a txtar get highlighted and some language support from IntelliJ.

Disclaimer: this is my first time working with the plugin SDK. Pieced the implementation together with some code search on github.

Example:
<img width="186" height="248" alt="image" src="https://github.com/user-attachments/assets/1efe73fd-2605-4638-a299-a5445ab6b52f" />