### PR TITLE
add ColorSettingsPage for Txtar language

### DIFF
--- a/src/main/kotlin/com/arran4/txtar/ColorSettingsPage.kt
+++ b/src/main/kotlin/com/arran4/txtar/ColorSettingsPage.kt
@@ -1,0 +1,52 @@
+package com.arran4.txtar
+
+import com.intellij.openapi.editor.colors.TextAttributesKey
+import com.intellij.openapi.fileTypes.SyntaxHighlighter
+import com.intellij.openapi.options.colors.AttributesDescriptor
+import com.intellij.openapi.options.colors.ColorDescriptor
+import com.intellij.openapi.options.colors.ColorSettingsPage
+import com.intellij.openapi.util.NlsContexts
+import org.jetbrains.annotations.NonNls
+import javax.swing.Icon
+
+class ColorSettingsPage : ColorSettingsPage {
+    private companion object {
+        val DESCRIPTORS: Array<AttributesDescriptor> = arrayOf(
+            AttributesDescriptor("Comment", TxtarSyntaxHighlighter.COMMENT),
+            AttributesDescriptor("Header", TxtarSyntaxHighlighter.HEADER),
+            AttributesDescriptor("Content", TxtarSyntaxHighlighter.CONTENT),
+        )
+    }
+
+    override fun getIcon(): Icon = TxtarIcons.FILE
+
+    override fun getHighlighter(): SyntaxHighlighter = TxtarSyntaxHighlighter()
+
+    override fun getDemoText(): @NonNls String = """
+            Some configuration files
+            -- api.yaml --
+            api:
+                version: v1.2.3
+                paths:
+                    - "/"
+                    -"/posts"
+            -- api.json --
+            {
+                "api": {
+                    "version": "v1.2.3",
+                    "paths": [
+                        "/",
+                        "/posts",
+                    ]
+                }
+            }
+        """.trimIndent()
+
+    override fun getAdditionalHighlightingTagToDescriptorMap(): Map<String?, TextAttributesKey?>? = null
+
+    override fun getAttributeDescriptors(): Array<out AttributesDescriptor?> = DESCRIPTORS
+
+    override fun getColorDescriptors(): Array<out ColorDescriptor?> = ColorDescriptor.EMPTY_ARRAY
+
+    override fun getDisplayName(): @NlsContexts.ConfigurableName String = "Txtar"
+}

--- a/src/main/resources/META-INF/plugin.xml
+++ b/src/main/resources/META-INF/plugin.xml
@@ -33,6 +33,8 @@
         <lang.syntaxHighlighterFactory
             language="Txtar"
             implementationClass="com.arran4.txtar.TxtarSyntaxHighlighterFactory"/>
+        <colorSettingsPage
+            implementation="com.arran4.txtar.ColorSettingsPage"/>
         <lang.foldingBuilder
             language="Txtar"
             implementationClass="com.arran4.txtar.TxtarFoldingBuilder"/>


### PR DESCRIPTION
Allows configuration of syntax highlighting colors in IntelliJs settings. With language injection enabled the file header can look like regular content.
Allow users to configure syntax highlighting colors.

Settings page demo:
<img width="981" height="718" alt="SCR-20260716-ujxv" src="https://github.com/user-attachments/assets/5a167b1b-dbde-43b4-91bc-fe6147e7a1c4" />

Result with language injection:
<img width="134" height="127" alt="SCR-20260716-ukca" src="https://github.com/user-attachments/assets/90a4a2e5-c01c-4688-846a-fa7ed88472ba" />
